### PR TITLE
JENKINS-66369 Add option to delete scans that have been prematurely aborted due to error(s) encountered during scan creation to the Jenkins plugin for Freestyle

### DIFF
--- a/src/main/java/com/veracode/jenkins/plugin/VeracodeNotifier.java
+++ b/src/main/java/com/veracode/jenkins/plugin/VeracodeNotifier.java
@@ -478,6 +478,7 @@ public class VeracodeNotifier extends Notifier {
     private final CredentialsBlock _credentials;
     private final boolean _waitforscan;
     private String _timeout;
+    private final boolean deleteIncompleteScan;
 
     // -------------------------------------------------------------------
     // Methods that correspond to identifiers referenced in config.jelly
@@ -546,6 +547,10 @@ public class VeracodeNotifier extends Notifier {
 
     public String getTimeout() {
         return this.getWaitForScan() ? EncryptionUtil.decrypt(this._timeout) : null;
+    }
+
+    public boolean isDeleteIncompleteScan() {
+        return this.deleteIncompleteScan;
     }
 
     public String getVid() {
@@ -887,6 +892,7 @@ public class VeracodeNotifier extends Notifier {
      * @param scanexcludespattern   a {@link java.lang.String} object.
      * @param waitForScan           a boolean.
      * @param timeout               a {@link java.lang.String} object.
+     * @param deleteIncompleteScan  a boolean.
      * @param credentials           a
      *                              {@link com.veracode.jenkins.plugin.data.CredentialsBlock}
      *                              object.
@@ -896,7 +902,7 @@ public class VeracodeNotifier extends Notifier {
             String sandboxname, boolean createsandbox, String version, String filenamepattern,
             String replacementpattern, String uploadincludespattern, String uploadexcludespattern,
             String scanincludespattern, String scanexcludespattern, boolean waitForScan,
-            String timeout, CredentialsBlock credentials) {
+            String timeout, boolean deleteIncompleteScan, CredentialsBlock credentials) {
         this._appname = appname;
         this._createprofile = createprofile;
         this._teams = teams;
@@ -916,6 +922,7 @@ public class VeracodeNotifier extends Notifier {
 
         this._waitforscan = waitForScan;
         this._timeout = this._waitforscan ? FormValidationUtil.formatTimeout(timeout) : null;
+        this.deleteIncompleteScan = deleteIncompleteScan;
 
         this._credentials = credentials;
     }

--- a/src/main/java/com/veracode/jenkins/plugin/VeracodePipelineRecorder.java
+++ b/src/main/java/com/veracode/jenkins/plugin/VeracodePipelineRecorder.java
@@ -363,7 +363,7 @@ public class VeracodePipelineRecorder extends Recorder implements SimpleBuildSte
                     run.getParent().getFullDisplayName(), applicationName, sandboxName, scanName,
                     criticality, scanIncludesPattern, scanExcludesPattern, fileNamePattern,
                     replacementPattern, pHost, pPort, pUser, pPassword, workspace,
-                    run.getEnvironment(listener), str_timeout, debug, uploadAndScanFilePaths);
+                    run.getEnvironment(listener), str_timeout, false, debug, uploadAndScanFilePaths);
 
             if (debug) {
                 ps.println(String.format("Calling wrapper with arguments:%n%s%n",
@@ -627,7 +627,7 @@ public class VeracodePipelineRecorder extends Recorder implements SimpleBuildSte
                     run.getParent().getFullDisplayName(), applicationName, sandboxName, scanName,
                     criticality, scanIncludesPattern, scanExcludesPattern, fileNamePattern,
                     replacementPattern, pHost, pPort, pUser, pPassword, workspace,
-                    run.getEnvironment(listener), str_timeout, debug, uploadAndScanFilePaths);
+                    run.getEnvironment(listener), str_timeout, false, debug, uploadAndScanFilePaths);
 
             String jarPath = jarFilePath + sep + execJarFile + ".jar";
             String cmd = "java -jar " + jarPath;

--- a/src/main/java/com/veracode/jenkins/plugin/args/UploadAndScanArgs.java
+++ b/src/main/java/com/veracode/jenkins/plugin/args/UploadAndScanArgs.java
@@ -34,6 +34,7 @@ public final class UploadAndScanArgs extends AbstractArgs {
     private static final String REPLACEMENT = SWITCH + "replacement";
     private static final String FILEPATH = SWITCH + "filepath";
     private static final String TIMEOUT = SWITCH + "scantimeout";
+    private static final String DELETEINCOMPLETESCAN = SWITCH + "deleteincompletescan";
     private static final String MAXRETRYCOUNT = SWITCH + "maxretrycount";
     private static final String DEBUG = SWITCH + "debug";
 
@@ -66,13 +67,14 @@ public final class UploadAndScanArgs extends AbstractArgs {
      * @param pattern       a {@link java.lang.String} object.
      * @param replacement   a {@link java.lang.String} object.
      * @param timeOut       a {@link java.lang.String} object.
+     * @param deleteIncompleteScan a boolean.
      * @param debug         a boolean.
      * @param filepath      a {@link java.lang.String} object.
      */
     private void addStdArguments(boolean bRemoteScan, String appname, String description,
             boolean createprofile, String teams, String criticality, String sandboxname,
             boolean createsandbox, String version, String include, String exclude, String pattern,
-            String replacement, String timeOut, boolean debug, String... filepath) {
+            String replacement, String timeOut, boolean deleteIncompleteScan, boolean debug, String... filepath) {
         // only add scantimeout if scan takes place from remote
         if (bRemoteScan) {
             if (!StringUtil.isNullOrEmpty(timeOut)) {
@@ -82,7 +84,7 @@ public final class UploadAndScanArgs extends AbstractArgs {
         }
 
         addStdArguments(appname, description, createprofile, teams, criticality, sandboxname,
-                createsandbox, version, include, exclude, pattern, replacement, debug, filepath);
+                createsandbox, version, include, exclude, pattern, replacement, deleteIncompleteScan, debug, filepath);
     }
 
     /**
@@ -101,12 +103,14 @@ public final class UploadAndScanArgs extends AbstractArgs {
      * @param exclude       a {@link java.lang.String} object.
      * @param pattern       a {@link java.lang.String} object.
      * @param replacement   a {@link java.lang.String} object.
+     * @param deleteIncompleteScan a boolean.
+     * @param debug         a boolean.
      * @param filepath      a {@link java.lang.String} object.
      */
     private void addStdArguments(String appname, String description, boolean createprofile,
             String teams, String criticality, String sandboxname, boolean createsandbox,
             String version, String include, String exclude, String pattern, String replacement,
-            boolean debug, String... filepath) {
+            boolean deleteIncompleteScan, boolean debug, String... filepath) {
         if (!StringUtil.isNullOrEmpty(appname)) {
             list.add(APPNAME);
             list.add(appname);
@@ -168,6 +172,11 @@ public final class UploadAndScanArgs extends AbstractArgs {
 
             list.add(REPLACEMENT);
             list.add(replacement);
+        }
+
+        if (deleteIncompleteScan) {
+            list.add(DELETEINCOMPLETESCAN);
+            list.add(Boolean.toString(true));
         }
 
         list.add(MAXRETRYCOUNT);
@@ -289,7 +298,7 @@ public final class UploadAndScanArgs extends AbstractArgs {
                 notifier.getScanincludespattern(), notifier.getScanexcludespattern(),
                 notifier.getFilenamepattern(), notifier.getReplacementpattern(), phost, pport,
                 puser, ppassword, build.getWorkspace(), envVars, notifier.getTimeout(),
-                descriptor.getDebug(), filePaths);
+                notifier.isDeleteIncompleteScan(), descriptor.getDebug(), filePaths);
     }
 
     /**
@@ -324,6 +333,7 @@ public final class UploadAndScanArgs extends AbstractArgs {
      * @param envVars             a {@link hudson.EnvVars} object.
      * @param debug               a boolean.
      * @param timeOut             a {@link java.lang.String} object.
+     * @param deleteIncompleteScan a boolean.
      * @param filePaths           an array of {@link java.lang.String} objects.
      * @return a {@link com.veracode.jenkins.plugin.args.UploadAndScanArgs} object.
      */
@@ -334,7 +344,7 @@ public final class UploadAndScanArgs extends AbstractArgs {
             String sandboxName, String scanName, String criticality, String scanIncludesPattern,
             String scanExcludesPattern, String fileNamePattern, String replacementPattern,
             String pHost, String pPort, String pUser, String pCredential, FilePath workspace,
-            hudson.EnvVars envVars, String timeOut, boolean debug, String[] filePaths) {
+            hudson.EnvVars envVars, String timeOut, boolean deleteIncompleteScan, boolean debug, String[] filePaths) {
 
         String description = null;
 
@@ -402,7 +412,7 @@ public final class UploadAndScanArgs extends AbstractArgs {
         args.addProxyConfiguration(phost, pport);
         args.addStdArguments(bRemoteScan, applicationName, description, createProfile, teams,
                 criticality, sandboxName, createSandbox, scanName, scanIncludesPattern,
-                scanExcludesPattern, fileNamePattern, replacementPattern, timeOut, debug,
+                scanExcludesPattern, fileNamePattern, replacementPattern, timeOut, deleteIncompleteScan, debug,
                 filePaths);
         args.addUserAgent(UserAgentUtil.getVersionDetails());
 

--- a/src/main/resources/com/veracode/jenkins/plugin/VeracodeNotifier/config.jelly
+++ b/src/main/resources/com/veracode/jenkins/plugin/VeracodeNotifier/config.jelly
@@ -67,13 +67,17 @@
 			</table>
 	</f:entry>
 
-	<f:optionalBlock title="Wait for scan to complete" name="waitForScan" checked="${instance.getWaitForScan() == true}" inline="true" >
+	<f:optionalBlock title="Wait for Scan to Complete" name="waitForScan" checked="${instance.getWaitForScan() == true}" inline="true" >
 		<f:entry title="Maximum Wait Time (in minutes)" field="timeout">
 			<f:textbox default="60"/>
 		</f:entry>
 	</f:optionalBlock>
 
-	<f:optionalBlock title="Use global Veracode API ID and key" name="credentials" negative="true" checked="${instance.getCredentials() == null ? descriptor.hasGlobalCredentials() : false}"> 
+	<f:entry title="Delete Incomplete Scan" field="deleteIncompleteScan">
+		<f:checkbox default="false" />
+	</f:entry>
+
+	<f:optionalBlock title="Use Global Veracode API ID and Key" name="credentials" negative="true" checked="${instance.getCredentials() == null ? descriptor.hasGlobalCredentials() : false}"> 
 		<f:section title="Veracode Credentials">
 
 			<f:entry title="API ID" field="vid">

--- a/src/main/resources/com/veracode/jenkins/plugin/VeracodeNotifier/help-deleteIncompleteScan.html
+++ b/src/main/resources/com/veracode/jenkins/plugin/VeracodeNotifier/help-deleteIncompleteScan.html
@@ -1,0 +1,9 @@
+<style>
+	.veracode.from-plugin
+	{
+		display:none;
+	}
+</style>
+<div class="veracode" id="deleteIncompleteScan-help-id-static-freestyle">
+	<p>Select this option to automatically delete the current scan if Jenkins encounters any errors when uploading files or starting the scan. With the scan deleted automatically, you can create subsequent scans without having to manually delete an incomplete scan.</p>
+</div>

--- a/src/test/java/com/veracode/jenkins/plugin/VeracodeNotifierTest.java
+++ b/src/test/java/com/veracode/jenkins/plugin/VeracodeNotifierTest.java
@@ -117,7 +117,7 @@ public class VeracodeNotifierTest {
                 AbstractBuild.class, BuildListener.class, PrintStream.class, boolean.class);
         runScanFromRemoteMethod.setAccessible(true);
         VeracodeNotifier notifier = new VeracodeNotifier("appname", true, null, "criticality", null, false, "version",
-                null, null, "**/**.*", null, "**/**.jar", "**/**.war", true, null, null);
+                null, null, "**/**.*", null, "**/**.jar", "**/**.war", true, null, false, null);
         boolean success = (boolean) runScanFromRemoteMethod.invoke(notifier, abstractBuild, buildListener, printStream,
                 true);
         Assert.assertTrue(success);

--- a/src/test/java/com/veracode/jenkins/plugin/VeracodePipelineRecorderTest.java
+++ b/src/test/java/com/veracode/jenkins/plugin/VeracodePipelineRecorderTest.java
@@ -100,7 +100,7 @@ public class VeracodePipelineRecorderTest {
                 anyBoolean(), anyBoolean(), anyBoolean(), anyString(), anyBoolean(), anyString(),
                 anyString(), anyString(), anyString(), anyString(), anyString(), anyString(),
                 anyString(), anyString(), anyString(), anyString(), anyString(), anyString(),
-                anyString(), anyString(), anyString(), any(), any(), anyString(), anyBoolean(), any()))
+                anyString(), anyString(), anyString(), any(), any(), anyString(), anyBoolean(), anyBoolean(), any()))
                         .thenReturn(uploadAndScanArgs);
         when(run.getResult()).thenReturn(Result.FAILURE);
         
@@ -142,7 +142,7 @@ public class VeracodePipelineRecorderTest {
                 anyBoolean(), anyBoolean(), anyString(), anyBoolean(), anyString(), anyString(), anyString(),
                 anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), anyString(),
                 anyString(), anyString(), anyString(), anyString(), anyString(), any(), any(), anyString(),
-                anyBoolean(), any())).thenReturn(uploadAndScanArgs);
+                anyBoolean(), anyBoolean(), any())).thenReturn(uploadAndScanArgs);
         when(run.getResult()).thenReturn(Result.SUCCESS);
 
         veracodePipelineRecorder.perform(run, sampleFilePath, launcher, taskListener);

--- a/src/test/java/com/veracode/jenkins/plugin/args/UploadAndScanArgsTest.java
+++ b/src/test/java/com/veracode/jenkins/plugin/args/UploadAndScanArgsTest.java
@@ -1,5 +1,7 @@
 package com.veracode.jenkins.plugin.args;
 
+import static org.mockito.Matchers.any;
+
 import java.io.IOException;
 
 import org.junit.Assert;
@@ -7,12 +9,12 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
-import org.mockito.Matchers;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.veracode.jenkins.plugin.VeracodeNotifier;
+import com.veracode.jenkins.plugin.VeracodeNotifier.VeracodeDescriptor;
 import com.veracode.jenkins.plugin.data.CredentialsBlock;
 import com.veracode.jenkins.plugin.utils.FormValidationUtil;
 
@@ -24,7 +26,7 @@ import hudson.model.AbstractProject;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({
         AbstractBuild.class, UploadAndScanArgs.class, FormValidationUtil.class,
-        VeracodeNotifier.VeracodeDescriptor.class
+        VeracodeNotifier.class, VeracodeDescriptor.class, FilePath.class
 })
 public class UploadAndScanArgsTest {
 
@@ -49,6 +51,7 @@ public class UploadAndScanArgsTest {
         String scanExcludesPattern = "";
         boolean waitForScan = true;
         String timeout = "60";
+        boolean deleteIncompleteScan = true;
         boolean bRemoteScan = true;
 
         AbstractBuild build = PowerMockito.mock(AbstractBuild.class);
@@ -59,11 +62,11 @@ public class UploadAndScanArgsTest {
         PowerMockito.mockStatic(FormValidationUtil.class);
         CredentialsBlock credentials = new CredentialsBlock("v_id", "v_key", "v_user", "v_pass");
         String[] filePaths = new String[2];
-        PowerMockito.when(FormValidationUtil.formatTimeout(Matchers.any())).thenReturn("60");
+        PowerMockito.when(FormValidationUtil.formatTimeout(any())).thenReturn("60");
         VeracodeNotifier veracodeNotifier = PowerMockito.spy(new VeracodeNotifier(appName,
                 createProfile, teams, criticality, sandboxName, createSandbox, version,
                 filenamePattern, replacementPattern, uploadIncludesPattern, uploadExcludesPattern,
-                scanIncludesPattern, scanExcludesPattern, waitForScan, timeout, credentials));
+                scanIncludesPattern, scanExcludesPattern, waitForScan, timeout, deleteIncompleteScan, credentials));
 
         FilePath filePath = new FilePath(tempFolder.newFolder("tempDir"));
 
@@ -81,6 +84,7 @@ public class UploadAndScanArgsTest {
         PowerMockito.doReturn("").when(veracodeNotifier).getFilenamepattern();
         PowerMockito.doReturn("").when(veracodeNotifier).getReplacementpattern();
         PowerMockito.doReturn("60").when(veracodeNotifier).getTimeout();
+        PowerMockito.doReturn(true).when(veracodeNotifier).isDeleteIncompleteScan();
         PowerMockito.doReturn(filePath).when(build).getWorkspace();
         PowerMockito.doReturn(appName).when(envVars).expand(appName);
         PowerMockito.when(veracodeDescriptor.getDebug()).thenReturn(true);
@@ -118,5 +122,76 @@ public class UploadAndScanArgsTest {
                 uploadAndScanArgs.list.contains("5"));
         Assert.assertTrue("debug is not visible in uploadAndScanArgs",
                 uploadAndScanArgs.list.contains("-debug"));
+        Assert.assertTrue("deleteincompletescan is not visible in uploadAndScanArgs",
+                uploadAndScanArgs.list.contains("-deleteincompletescan"));
+    }
+
+    @Test
+    public void testNewUploadAndScanArgsWithDeleteIncompleteScanFlagTrue() throws IOException {
+
+        AbstractBuild build = PowerMockito.mock(AbstractBuild.class);
+        EnvVars envVars = PowerMockito.mock(EnvVars.class);
+        VeracodeDescriptor veracodeDescriptor = PowerMockito.mock(VeracodeDescriptor.class);
+        AbstractProject abstractProject = PowerMockito.mock(AbstractProject.class);
+        PowerMockito.mockStatic(FormValidationUtil.class);
+        CredentialsBlock credentials = new CredentialsBlock("v_id", "v_key", null, null);
+        PowerMockito.when(FormValidationUtil.formatTimeout(any())).thenReturn("60");
+        VeracodeNotifier veracodeNotifier = PowerMockito.spy(new VeracodeNotifier("test_app", true, "test_team", "High",
+                "test_sandbox", true, "1.0", "**/*.jar", "", "", "", "", "", true, "60", true, credentials));
+
+        PowerMockito.doReturn(veracodeDescriptor).when(veracodeNotifier).getDescriptor();
+        PowerMockito.when(veracodeDescriptor.getAutoappname()).thenReturn(true);
+        PowerMockito.when(veracodeDescriptor.getAutodescription()).thenReturn(true);
+        PowerMockito.when(veracodeDescriptor.getAutoversion()).thenReturn(true);
+        PowerMockito.when(veracodeDescriptor.getProxy()).thenReturn(false);
+        PowerMockito.when(build.getDisplayName()).thenReturn("project_name");
+        PowerMockito.when(build.getProject()).thenReturn(abstractProject);
+        PowerMockito.when(abstractProject.getDisplayName()).thenReturn("project_name");
+        PowerMockito.doReturn("High").when(veracodeNotifier).getCriticality();
+        PowerMockito.doReturn("60").when(veracodeNotifier).getTimeout();
+        PowerMockito.when(build.getWorkspace()).thenReturn(PowerMockito.mock(FilePath.class));
+        PowerMockito.when(envVars.expand(any())).thenReturn("anyString");
+        PowerMockito.when(veracodeDescriptor.getDebug()).thenReturn(true);
+        UploadAndScanArgs uploadAndScanArgs = UploadAndScanArgs.newUploadAndScanArgs(veracodeNotifier, build, envVars,
+                new String[2], true);
+
+        Assert.assertTrue("deleteincompletescan flag is not visible in uploadAndScanArgs",
+                uploadAndScanArgs.list.contains("-deleteincompletescan"));
+        Assert.assertTrue("deleteincompletescan flag is not true",
+                uploadAndScanArgs.list.get(uploadAndScanArgs.list.indexOf("-deleteincompletescan") + 1).equals("true"));
+    }
+
+    @Test
+    public void testNewUploadAndScanArgsWithDeleteIncompleteScanFlagFalse() throws IOException {
+
+        AbstractBuild build = PowerMockito.mock(AbstractBuild.class);
+        EnvVars envVars = PowerMockito.mock(EnvVars.class);
+        VeracodeNotifier.VeracodeDescriptor veracodeDescriptor = PowerMockito
+                .mock(VeracodeNotifier.VeracodeDescriptor.class);
+        AbstractProject abstractProject = PowerMockito.mock(AbstractProject.class);
+        PowerMockito.mockStatic(FormValidationUtil.class);
+        CredentialsBlock credentials = new CredentialsBlock("v_id", "v_key", null, null);
+        PowerMockito.when(FormValidationUtil.formatTimeout(any())).thenReturn("60");
+        VeracodeNotifier veracodeNotifier = PowerMockito.spy(new VeracodeNotifier("test_app", true, "test_team", "High",
+                "test_sandbox", true, "1.0", "**/*.jar", "", "", "", "", "", true, "60", false, credentials));
+
+        PowerMockito.doReturn(veracodeDescriptor).when(veracodeNotifier).getDescriptor();
+        PowerMockito.when(veracodeDescriptor.getAutoappname()).thenReturn(true);
+        PowerMockito.when(veracodeDescriptor.getAutodescription()).thenReturn(true);
+        PowerMockito.when(veracodeDescriptor.getAutoversion()).thenReturn(true);
+        PowerMockito.when(veracodeDescriptor.getProxy()).thenReturn(false);
+        PowerMockito.when(build.getDisplayName()).thenReturn("project_name");
+        PowerMockito.when(build.getProject()).thenReturn(abstractProject);
+        PowerMockito.when(abstractProject.getDisplayName()).thenReturn("project_name");
+        PowerMockito.doReturn("High").when(veracodeNotifier).getCriticality();
+        PowerMockito.doReturn("60").when(veracodeNotifier).getTimeout();
+        PowerMockito.when(build.getWorkspace()).thenReturn(PowerMockito.mock(FilePath.class));
+        PowerMockito.when(envVars.expand(any())).thenReturn("anyString");
+        PowerMockito.when(veracodeDescriptor.getDebug()).thenReturn(true);
+        UploadAndScanArgs uploadAndScanArgs = UploadAndScanArgs.newUploadAndScanArgs(veracodeNotifier, build, envVars,
+                new String[2], true);
+
+        Assert.assertFalse("deleteincompletescan flag is visible in uploadAndScanArgs",
+                uploadAndScanArgs.list.contains("-deleteincompletescan"));
     }
 }


### PR DESCRIPTION
JENKINS-66369 Add option to delete scans that have been prematurely aborted due to error(s) encountered during scan creation to the Jenkins plugin for Freestyle

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
