### PR TITLE
JENKINS-66370 Add option to delete scans that have been prematurely aborted due to error(s) encountered during scan creation to the Jenkins plugin for Pipeline

### DIFF
--- a/src/main/java/com/veracode/jenkins/plugin/VeracodePipelineRecorder.java
+++ b/src/main/java/com/veracode/jenkins/plugin/VeracodePipelineRecorder.java
@@ -67,6 +67,8 @@ public class VeracodePipelineRecorder extends Recorder implements SimpleBuildSte
     @DataBoundSetter
     public final Integer timeout;
     @DataBoundSetter
+    public final boolean deleteIncompleteScan;
+    @DataBoundSetter
     public final boolean createProfile;
     @DataBoundSetter
     public final String teams;
@@ -123,6 +125,7 @@ public class VeracodePipelineRecorder extends Recorder implements SimpleBuildSte
      * @param scanName              a {@link java.lang.String} object.
      * @param waitForScan           a boolean.
      * @param timeout               a int.
+     * @param deleteIncompleteScan  a boolean.
      * @param createProfile         a boolean.
      * @param teams                 a {@link java.lang.String} object.
      * @param createSandbox         a boolean.
@@ -146,7 +149,7 @@ public class VeracodePipelineRecorder extends Recorder implements SimpleBuildSte
      */
     @DataBoundConstructor
     public VeracodePipelineRecorder(String applicationName, String criticality, String sandboxName,
-            String scanName, boolean waitForScan, int timeout, boolean createProfile, String teams,
+            String scanName, boolean waitForScan, int timeout, boolean deleteIncompleteScan, boolean createProfile, String teams,
             boolean createSandbox, boolean timeoutFailsJob, boolean canFailJob, boolean debug,
             String uploadIncludesPattern, String uploadExcludesPattern, String scanIncludesPattern,
             String scanExcludesPattern, String fileNamePattern, String replacementPattern,
@@ -160,6 +163,7 @@ public class VeracodePipelineRecorder extends Recorder implements SimpleBuildSte
         this.timeoutFailsJob = timeoutFailsJob;
         this.waitForScan = waitForScan;
         this.timeout = waitForScan && timeout > 0 ? timeout : null;
+        this.deleteIncompleteScan = deleteIncompleteScan;
         this.createProfile = createProfile;
         this.teams = teams;
         this.createSandbox = createSandbox;
@@ -363,7 +367,7 @@ public class VeracodePipelineRecorder extends Recorder implements SimpleBuildSte
                     run.getParent().getFullDisplayName(), applicationName, sandboxName, scanName,
                     criticality, scanIncludesPattern, scanExcludesPattern, fileNamePattern,
                     replacementPattern, pHost, pPort, pUser, pPassword, workspace,
-                    run.getEnvironment(listener), str_timeout, false, debug, uploadAndScanFilePaths);
+                    run.getEnvironment(listener), str_timeout, deleteIncompleteScan, debug, uploadAndScanFilePaths);
 
             if (debug) {
                 ps.println(String.format("Calling wrapper with arguments:%n%s%n",
@@ -627,7 +631,7 @@ public class VeracodePipelineRecorder extends Recorder implements SimpleBuildSte
                     run.getParent().getFullDisplayName(), applicationName, sandboxName, scanName,
                     criticality, scanIncludesPattern, scanExcludesPattern, fileNamePattern,
                     replacementPattern, pHost, pPort, pUser, pPassword, workspace,
-                    run.getEnvironment(listener), str_timeout, false, debug, uploadAndScanFilePaths);
+                    run.getEnvironment(listener), str_timeout, deleteIncompleteScan, debug, uploadAndScanFilePaths);
 
             String jarPath = jarFilePath + sep + execJarFile + ".jar";
             String cmd = "java -jar " + jarPath;

--- a/src/main/resources/com/veracode/jenkins/plugin/VeracodePipelineRecorder/config.jelly
+++ b/src/main/resources/com/veracode/jenkins/plugin/VeracodePipelineRecorder/config.jelly
@@ -72,12 +72,16 @@
 			</table>
 	</f:entry>
 
-	<f:optionalBlock title="Wait for scan to complete" name="waitForScan" inline="true"> 
+	<f:optionalBlock title="Wait for Scan to Complete" name="waitForScan" inline="true"> 
 		<f:entry title="Maximum Wait Time (in minutes)" field="timeout">
 			<f:number default="60"/>
 		</f:entry>
 	</f:optionalBlock>
-	
+
+	<f:entry title="Delete Incomplete Scan" field="deleteIncompleteScan">
+		<f:checkbox default="false" />
+	</f:entry>
+
 	<f:entry title="API ID" field="vid">
 		<f:textbox />
 	</f:entry>

--- a/src/main/resources/com/veracode/jenkins/plugin/VeracodePipelineRecorder/help-deleteIncompleteScan.html
+++ b/src/main/resources/com/veracode/jenkins/plugin/VeracodePipelineRecorder/help-deleteIncompleteScan.html
@@ -1,0 +1,9 @@
+<style>
+	.veracode+.from-plugin
+	{
+		display:none;
+	}
+</style>
+<div class="veracode" id="deleteIncompleteScan-help-id-static-pipeline">
+	<p>Select this option to automatically delete the current scan if Jenkins encounters any errors when uploading files or starting the scan. With the scan deleted automatically, you can create subsequent scans without having to manually delete an incomplete scan.</p>
+</div>

--- a/src/test/java/com/veracode/jenkins/plugin/VeracodePipelineRecorderTest.java
+++ b/src/test/java/com/veracode/jenkins/plugin/VeracodePipelineRecorderTest.java
@@ -61,7 +61,7 @@ public class VeracodePipelineRecorderTest {
     public void testPerform() throws Exception {
 
         VeracodePipelineRecorder veracodePipelineRecorder = new VeracodePipelineRecorder("test_app",
-                "medium", "test_sand_box", "scan1", false, 100, true, "test_team", true, true, true,
+                "medium", "test_sand_box", "scan1", false, 100, false, true, "test_team", true, true, true,
                 true, "**/*.jar", "", "", "", "", "", true, false, "pHost", "pPort", "pUser",
                 "pPassword", "vid", "vkey");
         
@@ -112,7 +112,7 @@ public class VeracodePipelineRecorderTest {
 
         // Pass null value for both upload include and exclude pattern
         VeracodePipelineRecorder veracodePipelineRecorder = new VeracodePipelineRecorder("test_app", "medium",
-                "test_sand_box", "scan1", false, 100, true, "test_team", true, true, false, false, null, null, "", "",
+                "test_sand_box", "scan1", false, 100, false, true, "test_team", true, true, false, false, null, null, "", "",
                 "", "", false, false, "pHost", "pPort", "pUser", "pPassword", "vid", "vkey");
 
         Run run = PowerMockito.mock(Run.class);
@@ -222,7 +222,7 @@ public class VeracodePipelineRecorderTest {
                 Run.class, FilePath.class, TaskListener.class, PrintStream.class);
         runScanFromRemoteMethod.setAccessible(true);
         VeracodePipelineRecorder recorder = new VeracodePipelineRecorder("applicationName", "criticality", null,
-                "scanName", true, 60, true, null, false, false, true, true, "**/**.*", null, "**/**.jar", "**/**.war",
+                "scanName", true, 60, false, true, null, false, false, true, true, "**/**.*", null, "**/**.jar", "**/**.war",
                 null, null, false, false, null, null, null, null, "vid", "vkey");
         boolean success = (boolean) runScanFromRemoteMethod.invoke(recorder, run, filePath, taskListener, printStream);
         Assert.assertTrue(success);

--- a/src/test/java/com/veracode/jenkins/plugin/args/UploadAndScanArgsTest.java
+++ b/src/test/java/com/veracode/jenkins/plugin/args/UploadAndScanArgsTest.java
@@ -194,4 +194,42 @@ public class UploadAndScanArgsTest {
         Assert.assertFalse("deleteincompletescan flag is visible in uploadAndScanArgs",
                 uploadAndScanArgs.list.contains("-deleteincompletescan"));
     }
+
+    @Test
+    public void testNewUploadAndScanArgsForPipelineRecorderWithDeleteIncompleteScanFlagTrue() throws IOException {
+
+        EnvVars envVars = PowerMockito.mock(EnvVars.class);
+        AbstractBuild build = PowerMockito.mock(AbstractBuild.class);
+        FilePath filePath = PowerMockito.mock(FilePath.class);
+        PowerMockito.when(build.getWorkspace()).thenReturn(filePath);
+        PowerMockito.when(envVars.expand(any())).thenReturn("anyString");
+
+        UploadAndScanArgs uploadAndScanArgs = UploadAndScanArgs.newUploadAndScanArgs(false, false, false, false, false,
+                false, "", false, "vid", "vkey", "buildnum", "sample_project", "sample_app", "sample_sandbox", "scan",
+                "High", "**/**.java", "", "", "", "phost", "pport", "puser", "pcredential", filePath, envVars, "60",
+                true, true, new String[2]);
+
+        Assert.assertTrue("deleteincompletescan flag is not visible in upload and scan argument list",
+                uploadAndScanArgs.list.contains("-deleteincompletescan"));
+        Assert.assertTrue("deleteincompletescan flag is not set to true",
+                uploadAndScanArgs.list.get(uploadAndScanArgs.list.indexOf("-deleteincompletescan") + 1).equals("true"));
+    }
+
+    @Test
+    public void testNewUploadAndScanArgsForPipelineRecorderWithDeleteIncompleteScanFlagFalse() throws IOException {
+
+        EnvVars envVars = PowerMockito.mock(EnvVars.class);
+        AbstractBuild build = PowerMockito.mock(AbstractBuild.class);
+        FilePath filePath = PowerMockito.mock(FilePath.class);
+        PowerMockito.when(build.getWorkspace()).thenReturn(filePath);
+        PowerMockito.when(envVars.expand(any())).thenReturn("anyString");
+
+        UploadAndScanArgs uploadAndScanArgs = UploadAndScanArgs.newUploadAndScanArgs(false, false, false, false, false,
+                false, "", false, "vid", "vkey", "buildnum", "sample_project", "sample_app", "sample_sandbox", "scan",
+                "High", "**/**.java", "", "", "", "phost", "pport", "puser", "pcredential", filePath, envVars, "60",
+                false, true, new String[2]);
+
+        Assert.assertFalse("deleteincompletescan flag should not be visible in upload and scan argument list",
+                uploadAndScanArgs.list.contains("-deleteincompletescan"));
+    }
 }


### PR DESCRIPTION
JENKINS-66370 Add option to delete scans that have been prematurely aborted due to error(s) encountered during scan creation to the Jenkins plugin for Pipeline

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
