### PR TITLE
Fix JENKINS-70472: Mask sensitive data in logs and sanitize data when running in remote

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.37</version>
+        <version>3.44</version>
         <relativePath />
     </parent>
     <groupId>com.veracode.jenkins</groupId>
@@ -38,7 +38,7 @@
             <groupId>com.veracode.vosp.api.wrappers</groupId>
             <!-- Artifact name and version of the java wrapper -->
             <artifactId>vosp-api-wrappers-java</artifactId>
-            <version>22.6.10.2</version>
+            <version>22.10.10.4</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/veracode/jenkins/plugin/VeracodePipelineRecorder.java
+++ b/src/main/java/com/veracode/jenkins/plugin/VeracodePipelineRecorder.java
@@ -659,19 +659,10 @@ public class VeracodePipelineRecorder extends Recorder implements SimpleBuildSte
                     replacementPattern, pHost, pPort, pUser, pPassword, workspace,
                     run.getEnvironment(listener), str_timeout, deleteIncompleteScanLevel, debug, uploadAndScanFilePaths);
 
-            String jarPath = jarFilePath + sep + execJarFile + ".jar";
-            String cmd = "java -jar " + jarPath;
-            String[] cmds = uploadAndScanArguments.getArguments();
-
-            StringBuilder result = new StringBuilder();
-            result.append(cmd);
-            for (String _cmd : cmds) {
-                _cmd = RemoteScanUtil.formatParameterValue(_cmd);
-                result.append(" " + _cmd);
-            }
-
             ArgumentListBuilder command = new ArgumentListBuilder();
-            command.addTokenized(result.toString());
+            command.add("java").add("-jar").add(jarFilePath + sep + execJarFile + ".jar");
+            // Add other arguments to the command
+            RemoteScanUtil.addArgumentsToCommand(command, uploadAndScanArguments.getArguments());
 
             List<String> remoteCmd = command.toList();
             int iSize = remoteCmd.size();
@@ -686,16 +677,9 @@ public class VeracodePipelineRecorder extends Recorder implements SimpleBuildSte
             // masking the password related information
             boolean[] masks = new boolean[iSize];
             for (int i = 0; i < iSize; i++) {
-                if (iPosPassword != -1) {
-                    if (iPosPassword == i)
-                        masks[i] = true;
-                } else if (iPosKey != -1) {
-                    if (iPosKey == i)
-                        masks[i] = true;
-                } else if (iPosProxyPassword != -1) {
-                    if (iPosProxyPassword == i) {
-                        masks[i] = true;
-                    }
+                if ((iPosPassword == i && iPosPassword != -1) || (iPosKey == i && iPosKey != -1)
+                        || (iPosProxyPassword == i && iPosProxyPassword != -1)) {
+                    masks[i] = true;
                 } else {
                     masks[i] = false;
                 }

--- a/src/main/java/com/veracode/jenkins/plugin/args/AbstractArgs.java
+++ b/src/main/java/com/veracode/jenkins/plugin/args/AbstractArgs.java
@@ -1,6 +1,7 @@
 package com.veracode.jenkins.plugin.args;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import com.veracode.jenkins.plugin.utils.StringUtil;
@@ -29,6 +30,8 @@ public abstract class AbstractArgs {
     protected static final String VKEY = SWITCH + "vkey";
 
     protected static final String USERAGENT = SWITCH + "useragent";
+
+    public static final List<String> STRING_TYPE_ARGS_COMMON = Arrays.asList(VID, VKEY, PHOST, PPORT, PUSER, PPASSWORD);
 
     /**
      * A list of command line arguments.

--- a/src/main/java/com/veracode/jenkins/plugin/args/UploadAndScanArgs.java
+++ b/src/main/java/com/veracode/jenkins/plugin/args/UploadAndScanArgs.java
@@ -1,5 +1,8 @@
 package com.veracode.jenkins.plugin.args;
 
+import java.util.Arrays;
+import java.util.List;
+
 import com.veracode.jenkins.plugin.VeracodeNotifier;
 import com.veracode.jenkins.plugin.VeracodeNotifier.VeracodeDescriptor;
 import com.veracode.jenkins.plugin.common.Constant;
@@ -41,6 +44,9 @@ public final class UploadAndScanArgs extends AbstractArgs {
     private static final String CUSTOM_TIMESTAMP_VAR = "timestamp";
     private static final String CUSTOM_BUILD_NUMBER_VAR = "buildnumber";
     public static final String CUSTOM_PROJECT_NAME_VAR = "projectname";
+
+    public static final List<String> STRING_TYPE_ARGS_UPLOADANDSCAN = Arrays.asList(APPNAME, TEAMS, CRITICALITY,
+            SANDBOXNAME, VERSION, INCLUDE, EXCLUDE, PATTERN, REPLACEMENT);
 
     /**
      * Constructor for UploadAndScanArgs.

--- a/src/main/java/com/veracode/jenkins/plugin/utils/RemoteScanUtil.java
+++ b/src/main/java/com/veracode/jenkins/plugin/utils/RemoteScanUtil.java
@@ -1,12 +1,19 @@
 package com.veracode.jenkins.plugin.utils;
 
+import static com.veracode.jenkins.plugin.args.AbstractArgs.STRING_TYPE_ARGS_COMMON;
+import static com.veracode.jenkins.plugin.args.UploadAndScanArgs.STRING_TYPE_ARGS_UPLOADANDSCAN;
+
+import java.util.ArrayList;
 import java.util.List;
+
+import org.apache.commons.lang.StringEscapeUtils;
 
 import com.veracode.jenkins.plugin.common.Constant;
 
 import hudson.FilePath;
 import hudson.model.AbstractBuild;
 import hudson.model.Node;
+import hudson.util.ArgumentListBuilder;
 
 /**
  * The RemoteScanUtil is a utility class related to perfoming the scans in
@@ -123,6 +130,32 @@ public final class RemoteScanUtil {
             return (parameterValue.contains(" ") || parameterValue.contains("'"))
                     ? "\"" + parameterValue + "\""
                     : parameterValue;
+        }
+    }
+
+    /**
+     * Adds data passed from pipeline Groovy syntax to the command by escaping and
+     * adding quotes for any strings.
+     * 
+     * @param command   a {@link hudson.util.ArgumentListBuilder} object.
+     * @param arguments a {@link java.lang.String} object array.
+     */
+    public static void addArgumentsToCommand(ArgumentListBuilder command, String[] arguments) {
+        List<Integer> stringDataIndexes = new ArrayList<>();
+        int i = 0;
+        for (String _cmd : arguments) {
+
+            if (STRING_TYPE_ARGS_COMMON.contains(_cmd) || STRING_TYPE_ARGS_UPLOADANDSCAN.contains(_cmd)) {
+                stringDataIndexes.add(i + 1);
+            }
+
+            if (stringDataIndexes.contains(i)) {
+                command.addQuoted(StringEscapeUtils.escapeJava(_cmd));
+            } else {
+                command.add(_cmd);
+            }
+
+            i++;
         }
     }
 }


### PR DESCRIPTION
- Mask sensitive data in logs and sanitize data when running in remote
- Upgrade vosp-api-wrappers-java version (with Gson vulnerability fix) and upgrade the plugin parent version

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
