### PR TITLE
[JENKINS-74238] Remove unused onClick handler

### DIFF
--- a/src/main/resources/com/veracode/jenkins/plugin/VeracodePipelineRecorder/config.jelly
+++ b/src/main/resources/com/veracode/jenkins/plugin/VeracodePipelineRecorder/config.jelly
@@ -8,7 +8,7 @@
 	</f:entry>
 	
 	<f:entry title="Create Application" name="createProfile">
-		<f:checkbox default="false" field="createProfile" onclick="createProfileChecked(this.checked)"/>
+		<f:checkbox default="false" field="createProfile" />
 	</f:entry>
 	<f:entry title="Team Name" field="teams">
 		<f:textbox />


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

[JENKINS-74238](https://issues.jenkins.io/browse/JENKINS-74238)

Removed inline onClick handler to comply with CSP. 

Checked the source code for `createProfileChecked` but it is not declared anywhere. 

### Testing done

To test:
1. Create freesatyle project
2. in Post build steps select `Upload and Scan with Veracode`
3. Click the `Create Application` checkbox. behavior remains the same.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
